### PR TITLE
Add resource type selector menu

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -24,6 +24,16 @@ const (
 	// Future: ResourceTypeAppRun
 )
 
+// AllResourceTypes returns all available resource types
+var AllResourceTypes = []ResourceType{
+	ResourceTypeServer,
+	ResourceTypeSwitch,
+	ResourceTypeDNS,
+	ResourceTypeELB,
+	ResourceTypeGSLB,
+	ResourceTypeDB,
+}
+
 func (r ResourceType) String() string {
 	switch r {
 	case ResourceTypeServer:


### PR DESCRIPTION
## Summary
- Replace cycling through resource types ('t' key) with a menu-based selector
- Press 't' to open menu, j/k or arrows to navigate, Enter to select, Esc to cancel
- More scalable as resource types increase

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Manual testing: press 't' to open menu, navigate and select resource types