### PR TITLE
Add go fmt instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - The `main` branch is protected. Never commit directly to main.
 - Always create a feature branch and submit a pull request.
-- Before committing, always run `go fmt ./...` to format the code.
+- Before committing, always run `goimports -w .` to format code and organize imports.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Git Workflowセクションに `go fmt ./...` を実行する指示を追加

コミット前にコードフォーマットを忘れないようにするため。