### PR TITLE
Add Archive resource support

### DIFF
--- a/internal/archive.go
+++ b/internal/archive.go
@@ -1,0 +1,175 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// Archive represents an archive resource
+type Archive struct {
+	ID           string
+	Name         string
+	Desc         string
+	Zone         string
+	SizeGB       int
+	Scope        string
+	Availability string
+	CreatedAt    string
+}
+
+type ArchiveDetail struct {
+	Archive
+	Tags            []string
+	SourceDiskID    string
+	SourceArchiveID string
+	BundleInfo      string
+	ModifiedAt      string
+}
+
+// Implement list.Item interface for Archive
+func (a Archive) FilterValue() string {
+	return a.Name
+}
+
+func (a Archive) Title() string {
+	return a.Name
+}
+
+func (a Archive) Description() string {
+	desc := fmt.Sprintf("ID: %s", a.ID)
+	if a.Desc != "" {
+		desc += " | " + a.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListArchives(ctx context.Context) ([]Archive, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching archives from Sakura Cloud",
+		slog.String("zone", c.zone))
+
+	archiveOp := iaas.NewArchiveOp(c.caller)
+
+	searched, err := archiveOp.Find(ctx, c.zone, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch archives",
+			slog.String("zone", c.zone),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	archives := make([]Archive, 0, len(searched.Archives))
+	for _, a := range searched.Archives {
+		// Format created at
+		createdAt := ""
+		if !a.CreatedAt.IsZero() {
+			createdAt = a.CreatedAt.Format("2006-01-02")
+		}
+
+		archives = append(archives, Archive{
+			ID:           a.ID.String(),
+			Name:         a.Name,
+			Desc:         a.Description,
+			Zone:         c.zone,
+			SizeGB:       a.SizeMB / 1024,
+			Scope:        string(a.Scope),
+			Availability: string(a.Availability),
+			CreatedAt:    createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched archives",
+		slog.String("zone", c.zone),
+		slog.Int("count", len(archives)))
+
+	return archives, nil
+}
+
+func (c *SakuraClient) GetArchiveDetail(ctx context.Context, archiveID string) (*ArchiveDetail, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching archive detail from Sakura Cloud",
+		slog.String("zone", c.zone),
+		slog.String("archiveID", archiveID))
+
+	archiveOp := iaas.NewArchiveOp(c.caller)
+
+	id := types.StringID(archiveID)
+
+	a, err := archiveOp.Read(ctx, c.zone, id)
+	if err != nil {
+		slog.Error("Failed to fetch archive detail",
+			slog.String("zone", c.zone),
+			slog.String("archiveID", archiveID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !a.CreatedAt.IsZero() {
+		createdAt = a.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Format modified at
+	modifiedAt := ""
+	if !a.ModifiedAt.IsZero() {
+		modifiedAt = a.ModifiedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Get source info
+	sourceDiskID := ""
+	if !a.SourceDiskID.IsEmpty() {
+		sourceDiskID = a.SourceDiskID.String()
+	}
+	sourceArchiveID := ""
+	if !a.SourceArchiveID.IsEmpty() {
+		sourceArchiveID = a.SourceArchiveID.String()
+	}
+
+	// Get bundle info
+	bundleInfo := ""
+	if a.BundleInfo != nil && a.BundleInfo.HostClass != "" {
+		bundleInfo = a.BundleInfo.HostClass
+	}
+
+	detail := &ArchiveDetail{
+		Archive: Archive{
+			ID:           a.ID.String(),
+			Name:         a.Name,
+			Desc:         a.Description,
+			Zone:         c.zone,
+			SizeGB:       a.SizeMB / 1024,
+			Scope:        string(a.Scope),
+			Availability: string(a.Availability),
+			CreatedAt:    createdAt,
+		},
+		Tags:            a.Tags,
+		SourceDiskID:    sourceDiskID,
+		SourceArchiveID: sourceArchiveID,
+		BundleInfo:      bundleInfo,
+		ModifiedAt:      modifiedAt,
+	}
+
+	slog.Info("Successfully fetched archive detail",
+		slog.String("zone", c.zone),
+		slog.String("archiveID", archiveID))
+
+	return detail, nil
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeGSLB
 	ResourceTypeDB
 	ResourceTypeDisk
+	ResourceTypeArchive
 )
 
 // AllResourceTypes returns all available resource types
@@ -31,6 +32,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeGSLB,
 	ResourceTypeDB,
 	ResourceTypeDisk,
+	ResourceTypeArchive,
 }
 
 func (r ResourceType) String() string {
@@ -49,6 +51,8 @@ func (r ResourceType) String() string {
 		return "DB"
 	case ResourceTypeDisk:
 		return "Disk"
+	case ResourceTypeArchive:
+		return "Archive"
 	default:
 		return "Unknown"
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -389,3 +389,45 @@ func renderDiskDetail(detail *DiskDetail) string {
 
 	return b.String()
 }
+
+func renderArchiveDetail(detail *ArchiveDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("Archive: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Zone:        %s\n", detail.Zone))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Size:        %d GB\n", detail.SizeGB))
+	b.WriteString(fmt.Sprintf("Scope:       %s\n", detail.Scope))
+	b.WriteString(fmt.Sprintf("Availability: %s\n", detail.Availability))
+
+	if detail.BundleInfo != "" {
+		b.WriteString(fmt.Sprintf("Bundle:      %s\n", detail.BundleInfo))
+	}
+
+	if detail.SourceDiskID != "" {
+		b.WriteString(fmt.Sprintf("\nSource Disk: %s\n", detail.SourceDiskID))
+	}
+	if detail.SourceArchiveID != "" {
+		b.WriteString(fmt.Sprintf("Source Archive: %s\n", detail.SourceArchiveID))
+	}
+
+	if len(detail.Tags) > 0 {
+		b.WriteString(fmt.Sprintf("\nTags:        %s\n", strings.Join(detail.Tags, ", ")))
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+	if detail.ModifiedAt != "" {
+		b.WriteString(fmt.Sprintf("Modified:    %s\n", detail.ModifiedAt))
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Add Archive resource to view and manage Sakura Cloud archives
- Archives can be viewed in the TUI with the 't' key to switch resource types
- Detail view shows archive metadata including size, scope, availability, and source info

## Changes
- `internal/archive.go`: New file with Archive struct and API methods
- `internal/client.go`: Add ResourceTypeArchive to enum
- `internal/model.go`: Integrate Archive into TUI
- `internal/render.go`: Add renderArchiveDetail function

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)