### PR TITLE
Add VPCRouter resource support

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -21,6 +21,7 @@ const (
 	ResourceTypeDB
 	ResourceTypeDisk
 	ResourceTypeArchive
+	ResourceTypeVPCRouter
 )
 
 // AllResourceTypes returns all available resource types
@@ -33,6 +34,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeDB,
 	ResourceTypeDisk,
 	ResourceTypeArchive,
+	ResourceTypeVPCRouter,
 }
 
 func (r ResourceType) String() string {
@@ -53,6 +55,8 @@ func (r ResourceType) String() string {
 		return "Disk"
 	case ResourceTypeArchive:
 		return "Archive"
+	case ResourceTypeVPCRouter:
+		return "VPCRouter"
 	default:
 		return "Unknown"
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -431,3 +431,44 @@ func renderArchiveDetail(detail *ArchiveDetail) string {
 
 	return b.String()
 }
+
+func renderVPCRouterDetail(detail *VPCRouterDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("VPC Router: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Zone:        %s\n", detail.Zone))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Plan:        %s\n", detail.Plan))
+	b.WriteString(fmt.Sprintf("Version:     %d\n", detail.Version))
+	b.WriteString(fmt.Sprintf("Status:      %s\n", detail.InstanceStatus))
+
+	if len(detail.PublicIPAddresses) > 0 {
+		b.WriteString(fmt.Sprintf("Public IPs:  %s\n", strings.Join(detail.PublicIPAddresses, ", ")))
+	}
+
+	if len(detail.NICs) > 0 {
+		b.WriteString("\nNetwork Interfaces:\n")
+		for _, nic := range detail.NICs {
+			if nic.SwitchID != "" || nic.IPAddress != "" {
+				b.WriteString(fmt.Sprintf("  NIC%d: Switch=%s, IP=%s\n", nic.Index, nic.SwitchID, nic.IPAddress))
+			}
+		}
+	}
+
+	if len(detail.Tags) > 0 {
+		b.WriteString(fmt.Sprintf("\nTags:        %s\n", strings.Join(detail.Tags, ", ")))
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	return b.String()
+}

--- a/internal/vpcrouter.go
+++ b/internal/vpcrouter.go
@@ -1,0 +1,185 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// VPCRouter represents a VPC Router resource
+type VPCRouter struct {
+	ID             string
+	Name           string
+	Desc           string
+	Zone           string
+	Plan           string
+	Version        int
+	InstanceStatus string
+	CreatedAt      string
+}
+
+type VPCRouterDetail struct {
+	VPCRouter
+	Tags              []string
+	PublicIPAddresses []string
+	NICs              []VPCRouterNIC
+	CreatedAt         string
+}
+
+type VPCRouterNIC struct {
+	Index     int
+	SwitchID  string
+	IPAddress string
+}
+
+// Implement list.Item interface for VPCRouter
+func (v VPCRouter) FilterValue() string {
+	return v.Name
+}
+
+func (v VPCRouter) Title() string {
+	return v.Name
+}
+
+func (v VPCRouter) Description() string {
+	desc := fmt.Sprintf("ID: %s", v.ID)
+	if v.Desc != "" {
+		desc += " | " + v.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListVPCRouters(ctx context.Context) ([]VPCRouter, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching VPC routers from Sakura Cloud",
+		slog.String("zone", c.zone))
+
+	vpcRouterOp := iaas.NewVPCRouterOp(c.caller)
+
+	searched, err := vpcRouterOp.Find(ctx, c.zone, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch VPC routers",
+			slog.String("zone", c.zone),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	vpcRouterList := make([]VPCRouter, 0, len(searched.VPCRouters))
+	for _, v := range searched.VPCRouters {
+		// Format created at
+		createdAt := ""
+		if !v.CreatedAt.IsZero() {
+			createdAt = v.CreatedAt.Format("2006-01-02")
+		}
+
+		// Get plan name
+		planName := v.PlanID.String()
+
+		vpcRouterList = append(vpcRouterList, VPCRouter{
+			ID:             v.ID.String(),
+			Name:           v.Name,
+			Desc:           v.Description,
+			Zone:           c.zone,
+			Plan:           planName,
+			Version:        v.Version,
+			InstanceStatus: string(v.InstanceStatus),
+			CreatedAt:      createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched VPC routers",
+		slog.String("zone", c.zone),
+		slog.Int("count", len(vpcRouterList)))
+
+	return vpcRouterList, nil
+}
+
+func (c *SakuraClient) GetVPCRouterDetail(ctx context.Context, vpcRouterID string) (*VPCRouterDetail, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching VPC router detail from Sakura Cloud",
+		slog.String("zone", c.zone),
+		slog.String("vpcRouterID", vpcRouterID))
+
+	vpcRouterOp := iaas.NewVPCRouterOp(c.caller)
+
+	id := types.StringID(vpcRouterID)
+
+	v, err := vpcRouterOp.Read(ctx, c.zone, id)
+	if err != nil {
+		slog.Error("Failed to fetch VPC router detail",
+			slog.String("zone", c.zone),
+			slog.String("vpcRouterID", vpcRouterID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !v.CreatedAt.IsZero() {
+		createdAt = v.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Get plan name
+	planName := v.PlanID.String()
+
+	// Get public IP addresses
+	publicIPs := make([]string, 0)
+	for _, iface := range v.Interfaces {
+		if iface.IPAddress != "" {
+			publicIPs = append(publicIPs, iface.IPAddress)
+		}
+	}
+
+	// Get NICs
+	nics := make([]VPCRouterNIC, 0)
+	for i, iface := range v.Interfaces {
+		switchID := ""
+		if iface.SwitchID != 0 {
+			switchID = fmt.Sprintf("%d", iface.SwitchID)
+		}
+		nics = append(nics, VPCRouterNIC{
+			Index:     i,
+			SwitchID:  switchID,
+			IPAddress: iface.IPAddress,
+		})
+	}
+
+	detail := &VPCRouterDetail{
+		VPCRouter: VPCRouter{
+			ID:             v.ID.String(),
+			Name:           v.Name,
+			Desc:           v.Description,
+			Zone:           c.zone,
+			Plan:           planName,
+			Version:        v.Version,
+			InstanceStatus: string(v.InstanceStatus),
+			CreatedAt:      createdAt,
+		},
+		Tags:              v.Tags,
+		PublicIPAddresses: publicIPs,
+		NICs:              nics,
+		CreatedAt:         createdAt,
+	}
+
+	slog.Info("Successfully fetched VPC router detail",
+		slog.String("zone", c.zone),
+		slog.String("vpcRouterID", vpcRouterID))
+
+	return detail, nil
+}


### PR DESCRIPTION
## Summary
- VPCRouterリソースの表示に対応
- VPCRouter一覧表示とVPCRouter詳細表示を実装

## Changes
- `internal/vpcrouter.go`: VPCRouter, VPCRouterDetail構造体とAPIメソッドを追加
- `internal/client.go`: ResourceTypeVPCRouterを追加
- `internal/model.go`: VPCRouter用のメッセージタイプとハンドリングを追加
- `internal/render.go`: VPCRouter詳細表示用のレンダリング関数を追加

## Test plan
- [x] `make build` が成功することを確認
- [x] `make test` が成功することを確認
- [ ] 手動でVPCRouterの一覧・詳細表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)