### PR TITLE
Add PacketFilter resource support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,80 @@
+# sact リソース対応状況
+
+iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
+
+## 実装済み (11リソース)
+
+| リソース | ファイル | 説明 |
+|---------|---------|------|
+| Server | `internal/server.go` | サーバー |
+| Switch | `internal/switch.go` | スイッチ |
+| DNS | `internal/dns.go` | DNS |
+| ProxyLB (ELB) | `internal/elb.go` | エンハンスドロードバランサ |
+| GSLB | `internal/gslb.go` | 広域負荷分散 |
+| Database | `internal/db.go` | データベースアプライアンス |
+| Disk | `internal/disk.go` | ディスク |
+| Archive | `internal/archive.go` | アーカイブ |
+| Internet | `internal/internet.go` | ルーター |
+| VPCRouter | `internal/vpcrouter.go` | VPCルーター |
+| PacketFilter | `internal/packetfilter.go` | パケットフィルタ |
+
+## 未実装 - 高優先度 (運用管理で頻繁に使うリソース)
+
+| リソース | API名 | 説明 | ゾーン依存 |
+|---------|------|------|-----------|
+| LoadBalancer | LoadBalancerAPI | 標準ロードバランサ | Yes |
+| NFS | NFSAPI | NFSアプライアンス | Yes |
+| SSHKey | SSHKeyAPI | SSH公開鍵 | No |
+| AutoBackup | AutoBackupAPI | 自動バックアップ | Yes |
+| SimpleMonitor | SimpleMonitorAPI | シンプル監視 | No |
+
+## 未実装 - 中優先度 (特定用途で使うリソース)
+
+| リソース | API名 | 説明 | ゾーン依存 |
+|---------|------|------|-----------|
+| Bridge | BridgeAPI | ブリッジ接続 | Yes |
+| CDROM | CDROMAPI | ISOイメージ | Yes |
+| LocalRouter | LocalRouterAPI | ローカルルーター | No |
+| MobileGateway | MobileGatewayAPI | モバイルゲートウェイ | Yes |
+| SIM | SIMAPI | SIM | No |
+| PrivateHost | PrivateHostAPI | 専有ホスト | Yes |
+| Note | NoteAPI | スタートアップスクリプト | No |
+| Interface | InterfaceAPI | NIC | Yes |
+| EnhancedDB | EnhancedDBAPI | エンハンスドデータベース (TiDB) | No |
+| AutoScale | AutoScaleAPI | オートスケール | No |
+| ContainerRegistry | ContainerRegistryAPI | コンテナレジストリ | No |
+| CertificateAuthority | CertificateAuthorityAPI | マネージドPKI | No |
+| ESME | ESMEAPI | 2要素認証 (SMS) | No |
+
+## 未実装 - 低優先度 (参照専用・課金系・IP管理)
+
+| リソース | API名 | 説明 | ゾーン依存 |
+|---------|------|------|-----------|
+| IPAddress | IPAddressAPI | IPv4アドレス管理 | Yes |
+| IPv6Net | IPv6NetAPI | IPv6ネットワーク | Yes |
+| IPv6Addr | IPv6AddrAPI | IPv6アドレス | Yes |
+| Subnet | SubnetAPI | サブネット | Yes |
+| License | LicenseAPI | ライセンス (Windows等) | No |
+| Icon | IconAPI | アイコン | No |
+| Bill | BillAPI | 請求情報 | No |
+| Coupon | CouponAPI | クーポン情報 | No |
+| SimpleNotificationDestination | SimpleNotificationDestinationAPI | 通知先 | No |
+| SimpleNotificationGroup | SimpleNotificationGroupAPI | 通知グループ | No |
+
+## 次のステップ
+
+1. [ ] LoadBalancer - 標準ロードバランサの対応
+2. [ ] NFS - NFSアプライアンスの対応
+3. [x] PacketFilter - パケットフィルタの対応
+4. [ ] SSHKey - SSH公開鍵の対応
+5. [ ] AutoBackup - 自動バックアップの対応
+6. [ ] SimpleMonitor - シンプル監視の対応
+
+## 実装パターン
+
+新しいリソースを追加する際の基本パターン:
+
+1. `internal/<resource>.go` にリソース構造体と API ラッパーを実装
+2. `internal/client.go` の `ResourceType` に追加
+3. `internal/model.go` でリソース一覧取得とビュー表示を実装
+4. `internal/render.go` でテーブル表示ロジックを追加

--- a/internal/client.go
+++ b/internal/client.go
@@ -23,6 +23,7 @@ const (
 	ResourceTypeArchive
 	ResourceTypeInternet
 	ResourceTypeVPCRouter
+	ResourceTypePacketFilter
 )
 
 // AllResourceTypes returns all available resource types
@@ -37,6 +38,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeArchive,
 	ResourceTypeInternet,
 	ResourceTypeVPCRouter,
+	ResourceTypePacketFilter,
 }
 
 func (r ResourceType) String() string {
@@ -61,6 +63,8 @@ func (r ResourceType) String() string {
 		return "Internet"
 	case ResourceTypeVPCRouter:
 		return "VPCRouter"
+	case ResourceTypePacketFilter:
+		return "PacketFilter"
 	default:
 		return "Unknown"
 	}

--- a/internal/packetfilter.go
+++ b/internal/packetfilter.go
@@ -1,0 +1,169 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// PacketFilter represents a packet filter resource
+type PacketFilter struct {
+	ID        string
+	Name      string
+	Desc      string
+	Zone      string
+	RuleCount int
+	CreatedAt string
+}
+
+// PacketFilterRule represents a single rule in a packet filter
+type PacketFilterRule struct {
+	Protocol        string
+	SourceNetwork   string
+	SourcePort      string
+	DestinationPort string
+	Action          string
+	Description     string
+}
+
+type PacketFilterDetail struct {
+	PacketFilter
+	Rules          []PacketFilterRule
+	ExpressionHash string
+	CreatedAt      string
+}
+
+// Implement list.Item interface for PacketFilter
+func (p PacketFilter) FilterValue() string {
+	return p.Name
+}
+
+func (p PacketFilter) Title() string {
+	return p.Name
+}
+
+func (p PacketFilter) Description() string {
+	desc := fmt.Sprintf("ID: %s", p.ID)
+	if p.Desc != "" {
+		desc += " | " + p.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListPacketFilters(ctx context.Context) ([]PacketFilter, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching packet filters from Sakura Cloud",
+		slog.String("zone", c.zone))
+
+	pfOp := iaas.NewPacketFilterOp(c.caller)
+
+	searched, err := pfOp.Find(ctx, c.zone, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch packet filters",
+			slog.String("zone", c.zone),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	packetFilters := make([]PacketFilter, 0, len(searched.PacketFilters))
+	for _, pf := range searched.PacketFilters {
+		// Format created at
+		createdAt := ""
+		if !pf.CreatedAt.IsZero() {
+			createdAt = pf.CreatedAt.Format("2006-01-02")
+		}
+
+		// Count rules
+		ruleCount := len(pf.Expression)
+
+		packetFilters = append(packetFilters, PacketFilter{
+			ID:        pf.ID.String(),
+			Name:      pf.Name,
+			Desc:      pf.Description,
+			Zone:      c.zone,
+			RuleCount: ruleCount,
+			CreatedAt: createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched packet filters",
+		slog.String("zone", c.zone),
+		slog.Int("count", len(packetFilters)))
+
+	return packetFilters, nil
+}
+
+func (c *SakuraClient) GetPacketFilterDetail(ctx context.Context, packetFilterID string) (*PacketFilterDetail, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching packet filter detail from Sakura Cloud",
+		slog.String("zone", c.zone),
+		slog.String("packetFilterID", packetFilterID))
+
+	pfOp := iaas.NewPacketFilterOp(c.caller)
+
+	id := types.StringID(packetFilterID)
+
+	pf, err := pfOp.Read(ctx, c.zone, id)
+	if err != nil {
+		slog.Error("Failed to fetch packet filter detail",
+			slog.String("zone", c.zone),
+			slog.String("packetFilterID", packetFilterID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !pf.CreatedAt.IsZero() {
+		createdAt = pf.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Convert rules
+	rules := make([]PacketFilterRule, 0, len(pf.Expression))
+	for _, expr := range pf.Expression {
+		rules = append(rules, PacketFilterRule{
+			Protocol:        string(expr.Protocol),
+			SourceNetwork:   string(expr.SourceNetwork),
+			SourcePort:      string(expr.SourcePort),
+			DestinationPort: string(expr.DestinationPort),
+			Action:          string(expr.Action),
+			Description:     expr.Description,
+		})
+	}
+
+	detail := &PacketFilterDetail{
+		PacketFilter: PacketFilter{
+			ID:        pf.ID.String(),
+			Name:      pf.Name,
+			Desc:      pf.Description,
+			Zone:      c.zone,
+			RuleCount: len(pf.Expression),
+			CreatedAt: createdAt,
+		},
+		Rules:          rules,
+		ExpressionHash: pf.ExpressionHash,
+		CreatedAt:      createdAt,
+	}
+
+	slog.Info("Successfully fetched packet filter detail",
+		slog.String("zone", c.zone),
+		slog.String("packetFilterID", packetFilterID))
+
+	return detail, nil
+}

--- a/internal/render.go
+++ b/internal/render.go
@@ -503,3 +503,59 @@ func renderVPCRouterDetail(detail *VPCRouterDetail) string {
 
 	return b.String()
 }
+
+func renderPacketFilterDetail(detail *PacketFilterDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("Packet Filter: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Zone:        %s\n", detail.Zone))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Rules:       %d\n", detail.RuleCount))
+
+	if detail.ExpressionHash != "" {
+		b.WriteString(fmt.Sprintf("Hash:        %s\n", detail.ExpressionHash))
+	}
+
+	// Display rules in table format
+	if len(detail.Rules) > 0 {
+		b.WriteString("\nFilter Rules:\n")
+		b.WriteString(fmt.Sprintf("  %-8s %-18s %-12s %-12s %-8s %s\n",
+			"Protocol", "Source", "SrcPort", "DstPort", "Action", "Description"))
+		b.WriteString(fmt.Sprintf("  %-8s %-18s %-12s %-12s %-8s %s\n",
+			"--------", "------", "-------", "-------", "------", "-----------"))
+		for _, rule := range detail.Rules {
+			srcNet := rule.SourceNetwork
+			if srcNet == "" {
+				srcNet = "*"
+			}
+			srcPort := rule.SourcePort
+			if srcPort == "" {
+				srcPort = "*"
+			}
+			dstPort := rule.DestinationPort
+			if dstPort == "" {
+				dstPort = "*"
+			}
+			b.WriteString(fmt.Sprintf("  %-8s %-18s %-12s %-12s %-8s %s\n",
+				rule.Protocol,
+				srcNet,
+				srcPort,
+				dstPort,
+				rule.Action,
+				rule.Description))
+		}
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- PacketFilter リソースのサポートを追加
- パケットフィルタ一覧表示とフィルタルール詳細表示機能
- `t` キーでリソースタイプ選択時に PacketFilter を選択可能

## Test plan
- [ ] `t` キーで PacketFilter を選択できることを確認
- [ ] パケットフィルタ一覧が正しく表示されることを確認
- [ ] Enter キーで詳細表示が動作することを確認
- [ ] ゾーン切り替え (`z`) とリフレッシュ (`r`) が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)