### PR TITLE
Add NFS appliance resource support

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -25,6 +25,7 @@ const (
 	ResourceTypeVPCRouter
 	ResourceTypePacketFilter
 	ResourceTypeLoadBalancer
+	ResourceTypeNFS
 )
 
 // AllResourceTypes returns all available resource types
@@ -41,6 +42,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeVPCRouter,
 	ResourceTypePacketFilter,
 	ResourceTypeLoadBalancer,
+	ResourceTypeNFS,
 }
 
 func (r ResourceType) String() string {
@@ -69,6 +71,8 @@ func (r ResourceType) String() string {
 		return "PacketFilter"
 	case ResourceTypeLoadBalancer:
 		return "LoadBalancer"
+	case ResourceTypeNFS:
+		return "NFS"
 	default:
 		return "Unknown"
 	}

--- a/internal/nfs.go
+++ b/internal/nfs.go
@@ -1,0 +1,158 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// NFS represents a NFS appliance resource
+type NFS struct {
+	ID             string
+	Name           string
+	Desc           string
+	Zone           string
+	InstanceStatus string
+	SwitchName     string
+	CreatedAt      string
+}
+
+type NFSDetail struct {
+	NFS
+	Tags           []string
+	PlanID         string
+	SwitchID       string
+	DefaultRoute   string
+	NetworkMaskLen int
+	IPAddresses    []string
+	CreatedAt      string
+}
+
+// Implement list.Item interface for NFS
+func (n NFS) FilterValue() string {
+	return n.Name
+}
+
+func (n NFS) Title() string {
+	return n.Name
+}
+
+func (n NFS) Description() string {
+	desc := fmt.Sprintf("ID: %s", n.ID)
+	if n.Desc != "" {
+		desc += " | " + n.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListNFS(ctx context.Context) ([]NFS, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching NFS appliances from Sakura Cloud",
+		slog.String("zone", c.zone))
+
+	nfsOp := iaas.NewNFSOp(c.caller)
+
+	searched, err := nfsOp.Find(ctx, c.zone, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch NFS appliances",
+			slog.String("zone", c.zone),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	nfsList := make([]NFS, 0, len(searched.NFS))
+	for _, nfs := range searched.NFS {
+		// Format created at
+		createdAt := ""
+		if !nfs.CreatedAt.IsZero() {
+			createdAt = nfs.CreatedAt.Format("2006-01-02")
+		}
+
+		nfsList = append(nfsList, NFS{
+			ID:             nfs.ID.String(),
+			Name:           nfs.Name,
+			Desc:           nfs.Description,
+			Zone:           c.zone,
+			InstanceStatus: string(nfs.InstanceStatus),
+			SwitchName:     nfs.SwitchName,
+			CreatedAt:      createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched NFS appliances",
+		slog.String("zone", c.zone),
+		slog.Int("count", len(nfsList)))
+
+	return nfsList, nil
+}
+
+func (c *SakuraClient) GetNFSDetail(ctx context.Context, nfsID string) (*NFSDetail, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching NFS detail from Sakura Cloud",
+		slog.String("zone", c.zone),
+		slog.String("nfsID", nfsID))
+
+	nfsOp := iaas.NewNFSOp(c.caller)
+
+	id := types.StringID(nfsID)
+
+	nfs, err := nfsOp.Read(ctx, c.zone, id)
+	if err != nil {
+		slog.Error("Failed to fetch NFS detail",
+			slog.String("zone", c.zone),
+			slog.String("nfsID", nfsID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !nfs.CreatedAt.IsZero() {
+		createdAt = nfs.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Convert tags
+	tags := make([]string, 0, len(nfs.Tags))
+	tags = append(tags, nfs.Tags...)
+
+	detail := &NFSDetail{
+		NFS: NFS{
+			ID:             nfs.ID.String(),
+			Name:           nfs.Name,
+			Desc:           nfs.Description,
+			Zone:           c.zone,
+			InstanceStatus: string(nfs.InstanceStatus),
+			SwitchName:     nfs.SwitchName,
+			CreatedAt:      createdAt,
+		},
+		Tags:           tags,
+		PlanID:         nfs.PlanID.String(),
+		SwitchID:       nfs.SwitchID.String(),
+		DefaultRoute:   nfs.DefaultRoute,
+		NetworkMaskLen: nfs.NetworkMaskLen,
+		IPAddresses:    nfs.IPAddresses,
+		CreatedAt:      createdAt,
+	}
+
+	slog.Info("Successfully fetched NFS detail",
+		slog.String("zone", c.zone),
+		slog.String("nfsID", nfsID))
+
+	return detail, nil
+}

--- a/internal/render.go
+++ b/internal/render.go
@@ -623,3 +623,53 @@ func renderLoadBalancerDetail(detail *LoadBalancerDetail) string {
 
 	return b.String()
 }
+
+func renderNFSDetail(detail *NFSDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("NFS: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Zone:        %s\n", detail.Zone))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Status:      %s\n", detail.InstanceStatus))
+
+	if detail.PlanID != "" && detail.PlanID != "0" {
+		b.WriteString(fmt.Sprintf("Plan ID:     %s\n", detail.PlanID))
+	}
+
+	if len(detail.IPAddresses) > 0 {
+		b.WriteString(fmt.Sprintf("IP Addresses: %s\n", strings.Join(detail.IPAddresses, ", ")))
+	}
+
+	if detail.NetworkMaskLen > 0 {
+		b.WriteString(fmt.Sprintf("Network:     /%d\n", detail.NetworkMaskLen))
+	}
+
+	if detail.DefaultRoute != "" {
+		b.WriteString(fmt.Sprintf("Gateway:     %s\n", detail.DefaultRoute))
+	}
+
+	if detail.SwitchID != "" && detail.SwitchID != "0" {
+		b.WriteString(fmt.Sprintf("Switch ID:   %s\n", detail.SwitchID))
+	}
+
+	if detail.SwitchName != "" {
+		b.WriteString(fmt.Sprintf("Switch Name: %s\n", detail.SwitchName))
+	}
+
+	if len(detail.Tags) > 0 {
+		b.WriteString(fmt.Sprintf("\nTags:        %s\n", strings.Join(detail.Tags, ", ")))
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Add NFS appliance resource type to the TUI
- Implement list view showing NFS appliances with switch name and status
- Implement detail view with IP addresses, network configuration, and switch info

## Test plan
- [ ] Switch to NFS resource type using 't' key
- [ ] Verify NFS appliances are listed correctly
- [ ] Press Enter to view NFS detail
- [ ] Verify zone switching works with 'z' key
- [ ] Verify refresh works with 'r' key

🤖 Generated with [Claude Code](https://claude.ai/claude-code)