### PR TITLE
Add SSH key resource support

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -26,6 +26,7 @@ const (
 	ResourceTypePacketFilter
 	ResourceTypeLoadBalancer
 	ResourceTypeNFS
+	ResourceTypeSSHKey
 )
 
 // AllResourceTypes returns all available resource types
@@ -43,6 +44,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypePacketFilter,
 	ResourceTypeLoadBalancer,
 	ResourceTypeNFS,
+	ResourceTypeSSHKey,
 }
 
 func (r ResourceType) String() string {
@@ -73,6 +75,8 @@ func (r ResourceType) String() string {
 		return "LoadBalancer"
 	case ResourceTypeNFS:
 		return "NFS"
+	case ResourceTypeSSHKey:
+		return "SSHKey"
 	default:
 		return "Unknown"
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -673,3 +673,41 @@ func renderNFSDetail(detail *NFSDetail) string {
 
 	return b.String()
 }
+
+func renderSSHKeyDetail(detail *SSHKeyDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("SSH Key: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Fingerprint: %s\n", detail.Fingerprint))
+
+	if detail.PublicKey != "" {
+		b.WriteString("\nPublic Key:\n")
+		// Split long public key for better display
+		pubKey := detail.PublicKey
+		if len(pubKey) > 80 {
+			for i := 0; i < len(pubKey); i += 80 {
+				end := i + 80
+				if end > len(pubKey) {
+					end = len(pubKey)
+				}
+				b.WriteString(fmt.Sprintf("  %s\n", pubKey[i:end]))
+			}
+		} else {
+			b.WriteString(fmt.Sprintf("  %s\n", pubKey))
+		}
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	return b.String()
+}

--- a/internal/sshkey.go
+++ b/internal/sshkey.go
@@ -1,0 +1,128 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// SSHKey represents a SSH public key resource
+type SSHKey struct {
+	ID          string
+	Name        string
+	Desc        string
+	Fingerprint string
+	CreatedAt   string
+}
+
+type SSHKeyDetail struct {
+	SSHKey
+	PublicKey string
+	CreatedAt string
+}
+
+// Implement list.Item interface for SSHKey
+func (s SSHKey) FilterValue() string {
+	return s.Name
+}
+
+func (s SSHKey) Title() string {
+	return s.Name
+}
+
+func (s SSHKey) Description() string {
+	desc := fmt.Sprintf("ID: %s", s.ID)
+	if s.Desc != "" {
+		desc += " | " + s.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListSSHKeys(ctx context.Context) ([]SSHKey, error) {
+	slog.Info("Fetching SSH keys from Sakura Cloud")
+
+	sshKeyOp := iaas.NewSSHKeyOp(c.caller)
+
+	searched, err := sshKeyOp.Find(ctx, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch SSH keys",
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	sshKeys := make([]SSHKey, 0, len(searched.SSHKeys))
+	for _, key := range searched.SSHKeys {
+		// Format created at
+		createdAt := ""
+		if !key.CreatedAt.IsZero() {
+			createdAt = key.CreatedAt.Format("2006-01-02")
+		}
+
+		// Truncate fingerprint for display
+		fingerprint := key.Fingerprint
+		if len(fingerprint) > 30 {
+			fingerprint = fingerprint[:27] + "..."
+		}
+
+		sshKeys = append(sshKeys, SSHKey{
+			ID:          key.ID.String(),
+			Name:        key.Name,
+			Desc:        key.Description,
+			Fingerprint: fingerprint,
+			CreatedAt:   createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched SSH keys",
+		slog.Int("count", len(sshKeys)))
+
+	return sshKeys, nil
+}
+
+func (c *SakuraClient) GetSSHKeyDetail(ctx context.Context, sshKeyID string) (*SSHKeyDetail, error) {
+	slog.Info("Fetching SSH key detail from Sakura Cloud",
+		slog.String("sshKeyID", sshKeyID))
+
+	sshKeyOp := iaas.NewSSHKeyOp(c.caller)
+
+	id := types.StringID(sshKeyID)
+
+	key, err := sshKeyOp.Read(ctx, id)
+	if err != nil {
+		slog.Error("Failed to fetch SSH key detail",
+			slog.String("sshKeyID", sshKeyID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !key.CreatedAt.IsZero() {
+		createdAt = key.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	detail := &SSHKeyDetail{
+		SSHKey: SSHKey{
+			ID:          key.ID.String(),
+			Name:        key.Name,
+			Desc:        key.Description,
+			Fingerprint: key.Fingerprint,
+			CreatedAt:   createdAt,
+		},
+		PublicKey: key.PublicKey,
+		CreatedAt: createdAt,
+	}
+
+	slog.Info("Successfully fetched SSH key detail",
+		slog.String("sshKeyID", sshKeyID))
+
+	return detail, nil
+}


### PR DESCRIPTION
## Summary
- Add SSHKey resource type to the TUI
- Implement list view showing SSH keys with fingerprint
- Implement detail view with full public key display
- SSHKey is a global resource (zone-independent, like DNS/ELB/GSLB)

## Test plan
- [ ] Switch to SSHKey resource type using 't' key
- [ ] Verify SSH keys are listed correctly with fingerprints
- [ ] Press Enter to view SSH key detail with public key
- [ ] Verify zone indicator shows "global"
- [ ] Verify refresh works with 'r' key

🤖 Generated with [Claude Code](https://claude.ai/claude-code)