### PR TITLE
Add AutoBackup resource support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 
-## 実装済み (12リソース)
+## 実装済み (15リソース)
 
 | リソース | ファイル | 説明 |
 |---------|---------|------|
@@ -18,14 +18,14 @@ iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 | VPCRouter | `internal/vpcrouter.go` | VPCルーター |
 | PacketFilter | `internal/packetfilter.go` | パケットフィルタ |
 | LoadBalancer | `internal/loadbalancer.go` | 標準ロードバランサ |
+| NFS | `internal/nfs.go` | NFSアプライアンス |
+| SSHKey | `internal/sshkey.go` | SSH公開鍵 |
+| AutoBackup | `internal/autobackup.go` | 自動バックアップ |
 
 ## 未実装 - 高優先度 (運用管理で頻繁に使うリソース)
 
 | リソース | API名 | 説明 | ゾーン依存 |
 |---------|------|------|-----------|
-| NFS | NFSAPI | NFSアプライアンス | Yes |
-| SSHKey | SSHKeyAPI | SSH公開鍵 | No |
-| AutoBackup | AutoBackupAPI | 自動バックアップ | Yes |
 | SimpleMonitor | SimpleMonitorAPI | シンプル監視 | No |
 
 ## 未実装 - 中優先度 (特定用途で使うリソース)
@@ -64,10 +64,10 @@ iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 ## 次のステップ
 
 1. [x] LoadBalancer - 標準ロードバランサの対応
-2. [ ] NFS - NFSアプライアンスの対応
+2. [x] NFS - NFSアプライアンスの対応
 3. [x] PacketFilter - パケットフィルタの対応
-4. [ ] SSHKey - SSH公開鍵の対応
-5. [ ] AutoBackup - 自動バックアップの対応
+4. [x] SSHKey - SSH公開鍵の対応
+5. [x] AutoBackup - 自動バックアップの対応
 6. [ ] SimpleMonitor - シンプル監視の対応
 
 ## 実装パターン

--- a/internal/autobackup.go
+++ b/internal/autobackup.go
@@ -1,0 +1,195 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// AutoBackup represents an auto backup resource
+type AutoBackup struct {
+	ID           string
+	Name         string
+	Desc         string
+	Zone         string
+	DiskID       string
+	MaxBackups   int
+	Weekdays     string
+	Availability string
+	CreatedAt    string
+}
+
+type AutoBackupDetail struct {
+	AutoBackup
+	Tags           []string
+	BackupWeekdays []string
+	AccountID      string
+	ZoneName       string
+	CreatedAt      string
+	ModifiedAt     string
+}
+
+// Implement list.Item interface for AutoBackup
+func (a AutoBackup) FilterValue() string {
+	return a.Name
+}
+
+func (a AutoBackup) Title() string {
+	return a.Name
+}
+
+func (a AutoBackup) Description() string {
+	desc := fmt.Sprintf("ID: %s", a.ID)
+	if a.Desc != "" {
+		desc += " | " + a.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListAutoBackups(ctx context.Context) ([]AutoBackup, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching auto backups from Sakura Cloud",
+		slog.String("zone", c.zone))
+
+	autoBackupOp := iaas.NewAutoBackupOp(c.caller)
+
+	searched, err := autoBackupOp.Find(ctx, c.zone, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch auto backups",
+			slog.String("zone", c.zone),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	autoBackups := make([]AutoBackup, 0, len(searched.AutoBackups))
+	for _, ab := range searched.AutoBackups {
+		// Format created at
+		createdAt := ""
+		if !ab.CreatedAt.IsZero() {
+			createdAt = ab.CreatedAt.Format("2006-01-02")
+		}
+
+		// Get backup weekdays
+		weekdays := formatWeekdays(ab.BackupSpanWeekdays)
+
+		// Get disk ID
+		diskID := ""
+		if ab.DiskID != 0 {
+			diskID = ab.DiskID.String()
+		}
+
+		autoBackups = append(autoBackups, AutoBackup{
+			ID:           ab.ID.String(),
+			Name:         ab.Name,
+			Desc:         ab.Description,
+			Zone:         c.zone,
+			DiskID:       diskID,
+			MaxBackups:   ab.MaximumNumberOfArchives,
+			Weekdays:     weekdays,
+			Availability: string(ab.Availability),
+			CreatedAt:    createdAt,
+		})
+	}
+
+	slog.Info("Successfully fetched auto backups",
+		slog.String("zone", c.zone),
+		slog.Int("count", len(autoBackups)))
+
+	return autoBackups, nil
+}
+
+func (c *SakuraClient) GetAutoBackupDetail(ctx context.Context, autoBackupID string) (*AutoBackupDetail, error) {
+	if c.zone == "" {
+		slog.Error("Zone is not set in client")
+		return nil, fmt.Errorf("zone is not set")
+	}
+
+	slog.Info("Fetching auto backup detail from Sakura Cloud",
+		slog.String("zone", c.zone),
+		slog.String("autoBackupID", autoBackupID))
+
+	autoBackupOp := iaas.NewAutoBackupOp(c.caller)
+
+	id := types.StringID(autoBackupID)
+
+	ab, err := autoBackupOp.Read(ctx, c.zone, id)
+	if err != nil {
+		slog.Error("Failed to fetch auto backup detail",
+			slog.String("zone", c.zone),
+			slog.String("autoBackupID", autoBackupID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Format created at
+	createdAt := ""
+	if !ab.CreatedAt.IsZero() {
+		createdAt = ab.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Format modified at
+	modifiedAt := ""
+	if !ab.ModifiedAt.IsZero() {
+		modifiedAt = ab.ModifiedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Get backup weekdays as strings
+	weekdayStrs := make([]string, 0, len(ab.BackupSpanWeekdays))
+	for _, day := range ab.BackupSpanWeekdays {
+		weekdayStrs = append(weekdayStrs, string(day))
+	}
+
+	// Convert tags
+	tags := make([]string, 0, len(ab.Tags))
+	tags = append(tags, ab.Tags...)
+
+	detail := &AutoBackupDetail{
+		AutoBackup: AutoBackup{
+			ID:           ab.ID.String(),
+			Name:         ab.Name,
+			Desc:         ab.Description,
+			Zone:         c.zone,
+			DiskID:       ab.DiskID.String(),
+			MaxBackups:   ab.MaximumNumberOfArchives,
+			Weekdays:     formatWeekdays(ab.BackupSpanWeekdays),
+			Availability: string(ab.Availability),
+			CreatedAt:    createdAt,
+		},
+		Tags:           tags,
+		BackupWeekdays: weekdayStrs,
+		AccountID:      ab.AccountID.String(),
+		ZoneName:       ab.ZoneName,
+		CreatedAt:      createdAt,
+		ModifiedAt:     modifiedAt,
+	}
+
+	slog.Info("Successfully fetched auto backup detail",
+		slog.String("zone", c.zone),
+		slog.String("autoBackupID", autoBackupID))
+
+	return detail, nil
+}
+
+func formatWeekdays(weekdays []types.EDayOfTheWeek) string {
+	if len(weekdays) == 0 {
+		return "-"
+	}
+	strs := make([]string, 0, len(weekdays))
+	for _, day := range weekdays {
+		strs = append(strs, string(day))
+	}
+	return strings.Join(strs, ", ")
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -27,6 +27,7 @@ const (
 	ResourceTypeLoadBalancer
 	ResourceTypeNFS
 	ResourceTypeSSHKey
+	ResourceTypeAutoBackup
 )
 
 // AllResourceTypes returns all available resource types
@@ -45,6 +46,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeLoadBalancer,
 	ResourceTypeNFS,
 	ResourceTypeSSHKey,
+	ResourceTypeAutoBackup,
 }
 
 func (r ResourceType) String() string {
@@ -77,6 +79,8 @@ func (r ResourceType) String() string {
 		return "NFS"
 	case ResourceTypeSSHKey:
 		return "SSHKey"
+	case ResourceTypeAutoBackup:
+		return "AutoBackup"
 	default:
 		return "Unknown"
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -711,3 +711,51 @@ func renderSSHKeyDetail(detail *SSHKeyDetail) string {
 
 	return b.String()
 }
+
+func renderAutoBackupDetail(detail *AutoBackupDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("Auto Backup: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Zone:        %s\n", detail.Zone))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Availability: %s\n", detail.Availability))
+
+	if detail.DiskID != "" && detail.DiskID != "0" {
+		b.WriteString(fmt.Sprintf("Disk ID:     %s\n", detail.DiskID))
+	}
+
+	b.WriteString(fmt.Sprintf("Max Backups: %d\n", detail.MaxBackups))
+
+	if len(detail.BackupWeekdays) > 0 {
+		b.WriteString(fmt.Sprintf("Weekdays:    %s\n", strings.Join(detail.BackupWeekdays, ", ")))
+	}
+
+	if detail.ZoneName != "" {
+		b.WriteString(fmt.Sprintf("Zone Name:   %s\n", detail.ZoneName))
+	}
+
+	if detail.AccountID != "" && detail.AccountID != "0" {
+		b.WriteString(fmt.Sprintf("Account ID:  %s\n", detail.AccountID))
+	}
+
+	if len(detail.Tags) > 0 {
+		b.WriteString(fmt.Sprintf("\nTags:        %s\n", strings.Join(detail.Tags, ", ")))
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	if detail.ModifiedAt != "" {
+		b.WriteString(fmt.Sprintf("Modified:    %s\n", detail.ModifiedAt))
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- AutoBackup (自動バックアップ) リソースのサポートを追加
- 一覧表示と詳細表示に対応
- ゾーン依存リソースとして実装

## Changes
- `internal/autobackup.go`: AutoBackup/AutoBackupDetail構造体とAPIラッパー
- `internal/client.go`: ResourceTypeAutoBackup追加
- `internal/model.go`: メッセージタイプとハンドラー追加
- `internal/render.go`: renderAutoBackupDetail追加
- `TODO.md`: 実装済みリソースとして更新 (15リソース)

## Test plan
- [ ] `make all` でビルド成功を確認
- [ ] AutoBackupリソースの一覧表示を確認
- [ ] AutoBackupリソースの詳細表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)