### PR TITLE
Add SimpleMonitor resource support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 
-## 実装済み (15リソース)
+## 実装済み (16リソース)
 
 | リソース | ファイル | 説明 |
 |---------|---------|------|
@@ -21,12 +21,7 @@ iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 | NFS | `internal/nfs.go` | NFSアプライアンス |
 | SSHKey | `internal/sshkey.go` | SSH公開鍵 |
 | AutoBackup | `internal/autobackup.go` | 自動バックアップ |
-
-## 未実装 - 高優先度 (運用管理で頻繁に使うリソース)
-
-| リソース | API名 | 説明 | ゾーン依存 |
-|---------|------|------|-----------|
-| SimpleMonitor | SimpleMonitorAPI | シンプル監視 | No |
+| SimpleMonitor | `internal/simplemonitor.go` | シンプル監視 |
 
 ## 未実装 - 中優先度 (特定用途で使うリソース)
 
@@ -68,7 +63,7 @@ iaas-api-go v1.24.1 で利用可能なリソースの対応状況です。
 3. [x] PacketFilter - パケットフィルタの対応
 4. [x] SSHKey - SSH公開鍵の対応
 5. [x] AutoBackup - 自動バックアップの対応
-6. [ ] SimpleMonitor - シンプル監視の対応
+6. [x] SimpleMonitor - シンプル監視の対応
 
 ## 実装パターン
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -28,6 +28,7 @@ const (
 	ResourceTypeNFS
 	ResourceTypeSSHKey
 	ResourceTypeAutoBackup
+	ResourceTypeSimpleMonitor
 )
 
 // AllResourceTypes returns all available resource types
@@ -47,6 +48,7 @@ var AllResourceTypes = []ResourceType{
 	ResourceTypeNFS,
 	ResourceTypeSSHKey,
 	ResourceTypeAutoBackup,
+	ResourceTypeSimpleMonitor,
 }
 
 func (r ResourceType) String() string {
@@ -81,6 +83,8 @@ func (r ResourceType) String() string {
 		return "SSHKey"
 	case ResourceTypeAutoBackup:
 		return "AutoBackup"
+	case ResourceTypeSimpleMonitor:
+		return "SimpleMonitor"
 	default:
 		return "Unknown"
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -759,3 +759,87 @@ func renderAutoBackupDetail(detail *AutoBackupDetail) string {
 
 	return b.String()
 }
+
+func renderSimpleMonitorDetail(detail *SimpleMonitorDetail) string {
+	var b strings.Builder
+
+	b.WriteString(selectedStyle.Render(fmt.Sprintf("Simple Monitor: %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("ID:          %s\n", detail.ID))
+	b.WriteString(fmt.Sprintf("Target:      %s\n", detail.Target))
+
+	if detail.Desc != "" {
+		b.WriteString(fmt.Sprintf("Description: %s\n", detail.Desc))
+	}
+
+	b.WriteString(fmt.Sprintf("Protocol:    %s\n", detail.Protocol))
+	if detail.Port > 0 {
+		b.WriteString(fmt.Sprintf("Port:        %d\n", detail.Port))
+	}
+	if detail.Path != "" {
+		b.WriteString(fmt.Sprintf("Path:        %s\n", detail.Path))
+	}
+	if detail.Host != "" {
+		b.WriteString(fmt.Sprintf("Host:        %s\n", detail.Host))
+	}
+
+	enabledStr := "No"
+	if detail.Enabled {
+		enabledStr = "Yes"
+	}
+	b.WriteString(fmt.Sprintf("Enabled:     %s\n", enabledStr))
+
+	if detail.Health != "" {
+		b.WriteString(fmt.Sprintf("Health:      %s\n", detail.Health))
+	}
+
+	b.WriteString(fmt.Sprintf("\nMonitoring Settings:\n"))
+	b.WriteString(fmt.Sprintf("  Delay Loop:       %d sec\n", detail.DelayLoop))
+	b.WriteString(fmt.Sprintf("  Max Check Attempts: %d\n", detail.MaxCheckAttempts))
+	b.WriteString(fmt.Sprintf("  Retry Interval:   %d sec\n", detail.RetryInterval))
+	b.WriteString(fmt.Sprintf("  Timeout:          %d sec\n", detail.Timeout))
+
+	b.WriteString(fmt.Sprintf("\nNotification Settings:\n"))
+	emailEnabled := "No"
+	if detail.NotifyEmailEnabled {
+		emailEnabled = "Yes"
+	}
+	b.WriteString(fmt.Sprintf("  Email:            %s\n", emailEnabled))
+	slackEnabled := "No"
+	if detail.NotifySlackEnabled {
+		slackEnabled = "Yes"
+	}
+	b.WriteString(fmt.Sprintf("  Slack:            %s\n", slackEnabled))
+	if detail.NotifyInterval > 0 {
+		b.WriteString(fmt.Sprintf("  Notify Interval:  %d hours\n", detail.NotifyInterval))
+	}
+
+	if detail.LastCheckedAt != "" {
+		b.WriteString(fmt.Sprintf("\nLast Checked:   %s\n", detail.LastCheckedAt))
+	}
+	if detail.LastHealthChangedAt != "" {
+		b.WriteString(fmt.Sprintf("Health Changed: %s\n", detail.LastHealthChangedAt))
+	}
+
+	if len(detail.LatestLogs) > 0 {
+		b.WriteString("\nLatest Logs:\n")
+		for _, log := range detail.LatestLogs {
+			b.WriteString(fmt.Sprintf("  %s\n", log))
+		}
+	}
+
+	if len(detail.Tags) > 0 {
+		b.WriteString(fmt.Sprintf("\nTags:        %s\n", strings.Join(detail.Tags, ", ")))
+	}
+
+	if detail.CreatedAt != "" {
+		b.WriteString(fmt.Sprintf("\nCreated:     %s\n", detail.CreatedAt))
+	}
+
+	if detail.ModifiedAt != "" {
+		b.WriteString(fmt.Sprintf("Modified:    %s\n", detail.ModifiedAt))
+	}
+
+	return b.String()
+}

--- a/internal/simplemonitor.go
+++ b/internal/simplemonitor.go
@@ -1,0 +1,203 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/search"
+	"github.com/sacloud/iaas-api-go/types"
+)
+
+// SimpleMonitor represents a simple monitor resource
+type SimpleMonitor struct {
+	ID           string
+	Name         string
+	Desc         string
+	Target       string
+	Protocol     string
+	Enabled      bool
+	Health       string
+	Availability string
+}
+
+type SimpleMonitorDetail struct {
+	SimpleMonitor
+	Tags                []string
+	DelayLoop           int
+	MaxCheckAttempts    int
+	RetryInterval       int
+	Timeout             int
+	NotifyEmailEnabled  bool
+	NotifySlackEnabled  bool
+	NotifyInterval      int
+	Port                int
+	Path                string
+	Host                string
+	ContainsString      string
+	CreatedAt           string
+	ModifiedAt          string
+	LastCheckedAt       string
+	LastHealthChangedAt string
+	LatestLogs          []string
+}
+
+// Implement list.Item interface for SimpleMonitor
+func (s SimpleMonitor) FilterValue() string {
+	return s.Name
+}
+
+func (s SimpleMonitor) Title() string {
+	return s.Name
+}
+
+func (s SimpleMonitor) Description() string {
+	desc := fmt.Sprintf("Target: %s", s.Target)
+	if s.Desc != "" {
+		desc += " | " + s.Desc
+	}
+	return desc
+}
+
+func (c *SakuraClient) ListSimpleMonitors(ctx context.Context) ([]SimpleMonitor, error) {
+	slog.Info("Fetching simple monitors from Sakura Cloud")
+
+	simpleMonitorOp := iaas.NewSimpleMonitorOp(c.caller)
+
+	searched, err := simpleMonitorOp.Find(ctx, &iaas.FindCondition{
+		Sort: search.SortKeys{
+			search.SortKeyAsc("Name"),
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to fetch simple monitors",
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	simpleMonitors := make([]SimpleMonitor, 0, len(searched.SimpleMonitors))
+	for _, sm := range searched.SimpleMonitors {
+		// Get protocol
+		protocol := ""
+		if sm.HealthCheck != nil {
+			protocol = string(sm.HealthCheck.Protocol)
+		}
+
+		simpleMonitors = append(simpleMonitors, SimpleMonitor{
+			ID:           sm.ID.String(),
+			Name:         sm.Name,
+			Desc:         sm.Description,
+			Target:       sm.Target,
+			Protocol:     protocol,
+			Enabled:      bool(sm.Enabled),
+			Health:       "",
+			Availability: string(sm.Availability),
+		})
+	}
+
+	slog.Info("Successfully fetched simple monitors",
+		slog.Int("count", len(simpleMonitors)))
+
+	return simpleMonitors, nil
+}
+
+func (c *SakuraClient) GetSimpleMonitorDetail(ctx context.Context, simpleMonitorID string) (*SimpleMonitorDetail, error) {
+	slog.Info("Fetching simple monitor detail from Sakura Cloud",
+		slog.String("simpleMonitorID", simpleMonitorID))
+
+	simpleMonitorOp := iaas.NewSimpleMonitorOp(c.caller)
+
+	id := types.StringID(simpleMonitorID)
+
+	sm, err := simpleMonitorOp.Read(ctx, id)
+	if err != nil {
+		slog.Error("Failed to fetch simple monitor detail",
+			slog.String("simpleMonitorID", simpleMonitorID),
+			slog.Any("error", err))
+		return nil, err
+	}
+
+	// Get health status
+	healthStatus, err := simpleMonitorOp.HealthStatus(ctx, id)
+	if err != nil {
+		slog.Warn("Failed to fetch simple monitor health status",
+			slog.String("simpleMonitorID", simpleMonitorID),
+			slog.Any("error", err))
+		// Continue without health status
+	}
+
+	// Format created at
+	createdAt := ""
+	if !sm.CreatedAt.IsZero() {
+		createdAt = sm.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Format modified at
+	modifiedAt := ""
+	if !sm.ModifiedAt.IsZero() {
+		modifiedAt = sm.ModifiedAt.Format("2006-01-02 15:04:05")
+	}
+
+	// Get protocol and health check details
+	protocol := ""
+	port := 0
+	path := ""
+	host := ""
+	containsString := ""
+	if sm.HealthCheck != nil {
+		protocol = string(sm.HealthCheck.Protocol)
+		port = int(sm.HealthCheck.Port)
+		path = sm.HealthCheck.Path
+		host = sm.HealthCheck.Host
+		containsString = sm.HealthCheck.ContainsString
+	}
+
+	// Convert tags
+	tags := make([]string, 0, len(sm.Tags))
+	tags = append(tags, sm.Tags...)
+
+	detail := &SimpleMonitorDetail{
+		SimpleMonitor: SimpleMonitor{
+			ID:           sm.ID.String(),
+			Name:         sm.Name,
+			Desc:         sm.Description,
+			Target:       sm.Target,
+			Protocol:     protocol,
+			Enabled:      bool(sm.Enabled),
+			Health:       "",
+			Availability: string(sm.Availability),
+		},
+		Tags:               tags,
+		DelayLoop:          sm.DelayLoop,
+		MaxCheckAttempts:   sm.MaxCheckAttempts,
+		RetryInterval:      sm.RetryInterval,
+		Timeout:            sm.Timeout,
+		NotifyEmailEnabled: bool(sm.NotifyEmailEnabled),
+		NotifySlackEnabled: bool(sm.NotifySlackEnabled),
+		NotifyInterval:     sm.NotifyInterval,
+		Port:               port,
+		Path:               path,
+		Host:               host,
+		ContainsString:     containsString,
+		CreatedAt:          createdAt,
+		ModifiedAt:         modifiedAt,
+	}
+
+	// Add health status if available
+	if healthStatus != nil {
+		detail.Health = string(healthStatus.Health)
+		if !healthStatus.LastCheckedAt.IsZero() {
+			detail.LastCheckedAt = healthStatus.LastCheckedAt.Format("2006-01-02 15:04:05")
+		}
+		if !healthStatus.LastHealthChangedAt.IsZero() {
+			detail.LastHealthChangedAt = healthStatus.LastHealthChangedAt.Format("2006-01-02 15:04:05")
+		}
+		detail.LatestLogs = healthStatus.LatestLogs
+	}
+
+	slog.Info("Successfully fetched simple monitor detail",
+		slog.String("simpleMonitorID", simpleMonitorID))
+
+	return detail, nil
+}


### PR DESCRIPTION
## Summary
- SimpleMonitor (シンプル監視) リソースのサポートを追加
- 一覧表示と詳細表示に対応
- グローバル（ゾーン非依存）リソースとして実装

## Changes
- `internal/simplemonitor.go`: SimpleMonitor/SimpleMonitorDetail構造体とAPIラッパー
- `internal/client.go`: ResourceTypeSimpleMonitor追加
- `internal/model.go`: メッセージタイプとハンドラー追加
- `internal/render.go`: renderSimpleMonitorDetail追加
- `TODO.md`: 実装済みリソースを16に更新、高優先度リソース完了

## Test plan
- [ ] `make all` でビルド成功を確認
- [ ] SimpleMonitorリソースの一覧表示を確認
- [ ] SimpleMonitorリソースの詳細表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)